### PR TITLE
Fix Wildtype Issue #20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,7 @@ cgi_results/*
 
 # Development tests
 dev_tests/
+
+# debug files
+example_files/*_debug*
+.gitignore

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,20 @@
 Changelog
 ============
 
+0.4.2 - Stormy Saturn  (2023-04-05)
+---------------------------------------------
+
+**Added**
+
+**Fixed**
+
+* Bug fixes to handle new CGI wildtype biomarkers
+
+**Dependencies**
+
+**Deprecated**
+
+
 0.4.1 - Stormy Saturn  (2023-06-13)
 ---------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 querynator
 ==========
 
-
+foo
 .. image:: https://img.shields.io/pypi/v/querynator.svg
         :target: https://pypi.python.org/pypi/querynator
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 querynator
 ==========
 
-foo
+
 .. image:: https://img.shields.io/pypi/v/querynator.svg
         :target: https://pypi.python.org/pypi/querynator
 

--- a/querynator/__init__.py
+++ b/querynator/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Susanne Jodoin & Mark Polster"""
 __email__ = "susanne.jodoin@qbic.uni-tuebingen.de | mark.polster@uni-tuebingen.de"
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/querynator/query_api/cgi_api.py
+++ b/querynator/query_api/cgi_api.py
@@ -198,7 +198,7 @@ def delete_job_cgi(url, headers, output, logger):
         )
 
 
-def add_cgi_metadata(url, output, original_input, genome, filter_vep):
+def add_cgi_metadata(url, output, original_input, genome, filter_vep, logger):
     """
     Attach metadata to cgi query
 
@@ -208,6 +208,8 @@ def add_cgi_metadata(url, output, original_input, genome, filter_vep):
     :type output: str
     :param filter_vep: flag whether VEP based filtering should be performed
     :type filter_vep: bool
+    :param logger: prints info to console
+    :type logger: logging.Logger
     :return: None
     :raises: BadZipfile
 
@@ -268,5 +270,5 @@ def query_cgi(mutations, cnas, translocations, genome, cancer, headers, logger, 
     if done:
         logger.info("Downloading CGI results")
         download_cgi(url, headers, output, logger)
-        add_cgi_metadata(url, output, original_input, genome, filter_vep)
+        add_cgi_metadata(url, output, original_input, genome, filter_vep, logger)
         delete_job_cgi(url, headers, output, logger)

--- a/querynator/report_scripts/combine_cgi.py
+++ b/querynator/report_scripts/combine_cgi.py
@@ -258,7 +258,9 @@ def get_all_alterations(row):
     :return: link of biomarker to all related alterations
     :rtype: list
     """
-    if "(" in row["Alterations"]:
+    if row["Alterations"] is None:
+        return None
+    elif "(" in row["Alterations"]:
         # Alterations cell looks like this: EGFR (P546S), EGFR (G598V), EGFR (E690K), EGFR (S768I)
         alteration_links = [j.split(")")[0] for j in [i.split("(")[1] for i in row["Alterations"].split(", ")]]
     elif "wildtype" in row["Alterations"]:
@@ -274,7 +276,7 @@ def link_biomarkers(biomarkers_df):
     """
     add alteration-link column to "biomarkers.tsv"
 
-    :param biomarkers_df: pd DataFrame of the projects "biomarkers.tsv". Must not be empty!
+    :param biomarkers_df: pd DataFrame of the projects "biomarkers.tsv".
     :type biomarkers_df: pandas DataFrame
     :return: DataFrame of biomarkers with additional alteration-link col
     :rtype: pandas DataFrame

--- a/querynator/report_scripts/combine_cgi.py
+++ b/querynator/report_scripts/combine_cgi.py
@@ -297,17 +297,16 @@ def get_highest_evidence(row, biomarkers_linked):
     :rtype: str
     """
 
-    x = False
     if not pd.isnull(row["Protein Change_CGI"]):
         # escape special characters seen to be used in the Protein Change column
         if row["Protein Change_CGI"].startswith("*"):
             row["Protein Change_CGI"] = row["Protein Change_CGI"].replace("*", "\*")
-        for evidence in ["A", "B", "C", "D"]:
-            if not biomarkers_linked.loc[
-                (biomarkers_linked["alterations_link"].str.contains(row["Protein Change_CGI"]))
-                & (biomarkers_linked["Evidence"] == evidence)
-            ].empty:
-                return evidence
+
+        # highest evidence level has lowest char value (A<B<C<D)
+        max_evidence_level = biomarkers_linked.loc[(biomarkers_linked["alterations_link"].str.contains(row["Protein Change_CGI"]))]["Evidence"].min()
+
+        return max_evidence_level
+
     else:
         return row["Protein Change_CGI"]  # return nan
 

--- a/querynator/report_scripts/combine_cgi.py
+++ b/querynator/report_scripts/combine_cgi.py
@@ -274,13 +274,11 @@ def link_biomarkers(biomarkers_df):
     """
     add alteration-link column to "biomarkers.tsv"
 
-    :param biomarkers_df: pd DataFrame of the projects "biomarkers.tsv"
+    :param biomarkers_df: pd DataFrame of the projects "biomarkers.tsv". Must not be empty!
     :type biomarkers_df: pandas DataFrame
     :return: DataFrame of biomarkers with additional alteration-link col
     :rtype: pandas DataFrame
     """
-    # only works when biomarkers_df is not an empty df
-    
     biomarkers_df["alterations_link"] = biomarkers_df.apply(lambda x: get_all_alterations(x), axis=1)
 
     return biomarkers_df
@@ -304,7 +302,9 @@ def get_highest_evidence(row, biomarkers_linked):
             row["Protein Change_CGI"] = row["Protein Change_CGI"].replace("*", "\*")
 
         # highest evidence level has lowest char value (A<B<C<D)
-        max_evidence_level = biomarkers_linked.loc[(biomarkers_linked["alterations_link"].str.contains(row["Protein Change_CGI"]))]["Evidence"].min()
+        max_evidence_level = biomarkers_linked.loc[
+            (biomarkers_linked["alterations_link"].str.contains(row["Protein Change_CGI"]))
+        ]["Evidence"].min()
 
         return max_evidence_level
 
@@ -326,12 +326,14 @@ def check_wildtypes(biomarkers: pd.DataFrame, vcf: pd.DataFrame, logger) -> None
     wt_genes_variant_hits = vcf[vcf["SYMBOL_VEP"].isin(wt_biomarkers["Gene"])]
 
     if not wt_genes_variant_hits.empty:
-        logger.warning(f"There are variants in genes marked as wildtype by CGI {wt_genes_variant_hits['Gene_VEP'].unique()}")
-    
+        logger.warning(
+            f"There are variants in genes marked as wildtype by CGI {wt_genes_variant_hits['Gene_VEP'].unique()}"
+        )
+
     logger.info("CGI marked wildtype hits\n" + str(wt_biomarkers[["Alterations", "Diseases", "Evidence", "BioM"]]))
 
     return
-    
+
 
 def combine_cgi(cgi_path, outdir, logger):
     """

--- a/querynator/report_scripts/combine_cgi.py
+++ b/querynator/report_scripts/combine_cgi.py
@@ -258,7 +258,12 @@ def get_all_alterations(row):
     :return: link of biomarker to all related alterations
     :rtype: list
     """
-    alteration_links = [j.split(")")[0] for j in [i.split("(")[1] for i in row["Alterations"].split(", ")]]
+    if "wildtype" in row["Alterations"]:
+        # Alterations cell looks like this: PDGFRA wildtype
+        alteration_links = row["Alterations"]
+    else:
+        # Alterations cell looks like this: EGFR (P546S), EGFR (G598V), EGFR (E690K), EGFR (S768I)
+        alteration_links = [j.split(")")[0] for j in [i.split("(")[1] for i in row["Alterations"].split(", ")]]
     return alteration_links
 
 

--- a/querynator/report_scripts/combine_cgi.py
+++ b/querynator/report_scripts/combine_cgi.py
@@ -258,12 +258,15 @@ def get_all_alterations(row):
     :return: link of biomarker to all related alterations
     :rtype: list
     """
-    if "wildtype" in row["Alterations"]:
-        # Alterations cell looks like this: PDGFRA wildtype
-        alteration_links = row["Alterations"]
-    else:
+    if "(" in row["Alterations"]:
         # Alterations cell looks like this: EGFR (P546S), EGFR (G598V), EGFR (E690K), EGFR (S768I)
         alteration_links = [j.split(")")[0] for j in [i.split("(")[1] for i in row["Alterations"].split(", ")]]
+    elif "wildtype" in row["Alterations"]:
+        # Alterations cell looks like this: PDGFRA wildtype
+        alteration_links = row["Alterations"].split(" ")[1]
+    else:
+        raise ValueError(f"Unrecognized alteration format in row {row.index}: {row['Alterations']}!")
+
     return alteration_links
 
 

--- a/querynator/report_scripts/combine_cgi.py
+++ b/querynator/report_scripts/combine_cgi.py
@@ -280,10 +280,8 @@ def link_biomarkers(biomarkers_df):
     :rtype: pandas DataFrame
     """
     # only works when biomarkers_df is not an empty df
-    try:
-        biomarkers_df["alterations_link"] = biomarkers_df.apply(lambda x: get_all_alterations(x), axis=1)
-    except ValueError:
-        biomarkers_df["alterations_link"] = ""
+    
+    biomarkers_df["alterations_link"] = biomarkers_df.apply(lambda x: get_all_alterations(x), axis=1)
 
     return biomarkers_df
 

--- a/querynator/report_scripts/create_report.py
+++ b/querynator/report_scripts/create_report.py
@@ -720,7 +720,6 @@ def create_report_htmls(outdir, basename, civic_path, logger):
     vep_civic_cgi_merge["evidence_levels_comb"] = vep_civic_cgi_merge.apply(
         lambda x: assign_comb_evidence_labels(x), axis=1
     )
-    vep_civic_cgi_merge["report_name"] = add_variant_name_report(vep_civic_cgi_merge)
 
     # create "pretty_html_tables" for each tier
     tier_list = ["tier_1", "tier_2", "tier_3"]

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/qbic-pipelines/querynator",
-    version="0.4.1",
+    version="0.4.2",
     zip_safe=False,
 )


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).
Learn more about contributing: https://github.com/qbic-pipelines/querynator/CONTRIBUTING.md -->

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.rst` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->
Fixes #20 
- CGI "wildtype" biomarkers no longer raise an index error, but get parsed and logged
- warning is logged, if CGI returns a wildtype biomarker for a gene in which a variant was found
- expressive exception is raised, if unexpected alterations are added in the future
  - previous behaviour: `get_all_alterations` raises exception, `link_biomarkers` catches it and returns unlinked dataframe instead, leading to empty results but little knowledge of origin (silent error).
  - behaviour now: exception is not caught, terminating the program and enforcing developmental integration of new alteration
  - optional behaviour, one could implement: instead of raising an exception, log a warning. This seemed too silent to me, false/incomplete results could go undetected for too long

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**

<!-- Add any other context or screenshots here. -->
