### PR TITLE
use cancer type in CIViC results

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -180,6 +180,7 @@ A typical command to query the `Clinical Interpretations of Variants in Cancer -
         -v input_file.vcf \
         -o outdir \
         -g ref_genome [GRCh37, GRCh38, NCBI36]
+        -d 'breast adenocarcinoma'
 
 The command above generates the following result files using `CIViCpy <https://docs.civicpy.org/>`_.
 
@@ -192,6 +193,8 @@ The command above generates the following result files using `CIViCpy <https://d
 The querynator performs an ``exact`` search, meaning that variants in the KB must match the given coordinates, reference allele(s) and alternate allele(s) precisely.
 
 Using the ``filter_vep`` `flag <https://querynator.readthedocs.io/en/latest/usage.html#filtering-benign-variants>`_, the querynator can filter out benign variants in ``vcf`` files before querying the KB.
+
+Use `-d` or `--cancer-doid` to specify the cancer type. The cancer type must be a valid `Disease Ontology <https://disease-ontology.org/>`_ ID (DOID) or name.
 
 Input file format
 ==================

--- a/querynator/__main__.py
+++ b/querynator/__main__.py
@@ -427,7 +427,15 @@ def query_api_cgi(mutations, cnas, translocations, cancer, genome, token, email,
     show_default=True,
     default=False,
 )
-def query_api_civic(vcf, outdir, genome, filter_vep):
+#TODO use single cancer name and map to DO / oncotree
+@click.option(
+    "-d",
+    "--cancer-doid",
+    help="the cancer DOID (id or name) to be searched.",
+    default=None,
+    type=click.STRING,
+)
+def query_api_civic(vcf, outdir, genome, cancer_doid, filter_vep):
     try:
         result_dir = get_unique_querynator_dir(f"{outdir}")
         dirname, basename = os.path.split(result_dir)
@@ -440,7 +448,7 @@ def query_api_civic(vcf, outdir, genome, filter_vep):
 
             logger.info("Query the Clinical Interpretations of Variants In Cancer (CIViC)")
             # run analysis
-            query_civic(candidate_variants, result_dir, logger, vcf, genome, filter_vep)
+            query_civic(candidate_variants, result_dir, logger, vcf, genome, cancer_doid, filter_vep)
 
         else:
             logger.info("Query the Clinical Interpretations of Variants In Cancer (CIViC)")

--- a/querynator/__main__.py
+++ b/querynator/__main__.py
@@ -427,7 +427,7 @@ def query_api_cgi(mutations, cnas, translocations, cancer, genome, token, email,
     show_default=True,
     default=False,
 )
-#TODO use single cancer name and map to DO / oncotree
+# TODO use single cancer name and map to DO / oncotree
 @click.option(
     "-d",
     "--cancer-doid",

--- a/querynator/helper_functions/ontology.py
+++ b/querynator/helper_functions/ontology.py
@@ -2,9 +2,10 @@ from abc import ABC, abstractmethod
 import re
 from typing import List
 
+
 class Ontology(ABC):
     """Abstract class for ontologies.
-    
+
     Ontologies represent hierarchical relationships between terms.
     """
 
@@ -15,7 +16,7 @@ class Ontology(ABC):
         self.path = path
         self.ids = set()
         self.names = set()
-    
+
     @abstractmethod
     def get_all_ancestors(self, query_term):
         pass
@@ -26,20 +27,19 @@ class Ontology(ABC):
 
     def __contains__(self, item):
         return item in self.terms
-    
+
     def __repr__(self):
         return f"<Ontology.{self.__class__.__name__} {self.path}>"
-
 
     class Term:
         """represents an ontology term"""
 
-        def __init__(self, fields: dict, relationships: List['Ontology.Relationship']=None):
+        def __init__(self, fields: dict, relationships: List["Ontology.Relationship"] = None):
             try:
-                self.id = fields['id']
+                self.id = fields["id"]
             except KeyError:
                 raise ValueError("The 'id' field is required")
-            
+
             self.fields = fields
             self.relationships = relationships
 
@@ -61,11 +61,10 @@ class Ontology(ABC):
 
         def __getattr__(self, attr):
             return self.fields.get(attr)
-        
+
         def get(self, field):
             return self.fields.get(field)
 
-        
     class Relationship:
         """represents a relationship between two ontology terms"""
 
@@ -93,26 +92,26 @@ class Ontology(ABC):
 
 class DO(Ontology):
     """This class represents the Disease Ontology (DO)
-    
+
     www.disease-ontology.org
     """
-    
+
     def __init__(self, path):
         self.terms = {}
         self.ids = set()
         self.names = set()
         self.path = path
 
-        with open(path, 'r') as file:
+        with open(path, "r") as file:
             content = file.read()
-            terms = re.findall(r'\[Term\]\n(.*?)\n\n', content, re.DOTALL)
+            terms = re.findall(r"\[Term\]\n(.*?)\n\n", content, re.DOTALL)
             for term in terms:
                 term_dict = {}
-                lines = term.split('\n')
+                lines = term.split("\n")
                 for line in lines:
                     if line:
                         # parse fields into dict
-                        key, value = line.split(': ', 1)
+                        key, value = line.split(": ", 1)
                         if key in term_dict:
                             if isinstance(term_dict[key], list):
                                 term_dict[key].append(value)
@@ -121,11 +120,13 @@ class DO(Ontology):
                         else:
                             term_dict[key] = value
                 # create term object
-                is_a_values = term_dict.get('is_a')
+                is_a_values = term_dict.get("is_a")
                 if isinstance(is_a_values, list):
-                    relationships = [self.Relationship(term_dict.get("id"), "is_a", other.split(' ! ')[0]) for other in is_a_values]
+                    relationships = [
+                        self.Relationship(term_dict.get("id"), "is_a", other.split(" ! ")[0]) for other in is_a_values
+                    ]
                 elif isinstance(is_a_values, str):
-                    relationships = [self.Relationship(term_dict.get("id"), "is_a", is_a_values.split(' ! ')[0])]
+                    relationships = [self.Relationship(term_dict.get("id"), "is_a", is_a_values.split(" ! ")[0])]
                 else:
                     relationships = []
                 new_term = self.Term(term_dict, relationships)
@@ -136,7 +137,7 @@ class DO(Ontology):
 
     def get(self, query):
         """retrieve a term from the ontology
-        
+
         query can be one of id (str), id (int), or name (str)
         examples: "DOID:4947", 4947, "cholangiocarcinoma"
         """
@@ -152,10 +153,10 @@ class DO(Ontology):
                     return self.get_from_name(query.lower())
         else:
             raise ValueError(f"Invalid query type: {type(query)}")
-    
+
     def get_from_name(self, name) -> Ontology.Term:
         """retrieve a term from the ontology by name
-        
+
         :param name: the name of the term to retrieve
         :type  name: str
         :return: the term object if found, None otherwise
@@ -165,7 +166,7 @@ class DO(Ontology):
                 return term
         else:
             return None
-        
+
     def get_all_ancestors(self, query_term, includeSelf=False) -> list:
         # Get the term corresponding to the query DOID
         term = self.get(query_term)
@@ -178,7 +179,7 @@ class DO(Ontology):
                 current_term = stack.pop()
                 visited.add(current_term.id)
 
-                for parent in [self.get(rel.T2) for rel in term.relationships if rel.rtype == 'is_a']:
+                for parent in [self.get(rel.T2) for rel in term.relationships if rel.rtype == "is_a"]:
                     if parent.id not in visited:
                         ancestors.add(parent)
                         # Add the parent term to the stack for further traversal
@@ -193,7 +194,8 @@ class DO(Ontology):
 
 class OncoTree(Ontology):
     """This class represents the OncoTree ontology
-    
+
     http://oncotree.info/
     """
+
     ...

--- a/querynator/helper_functions/ontology.py
+++ b/querynator/helper_functions/ontology.py
@@ -1,0 +1,199 @@
+from abc import ABC, abstractmethod
+import re
+from typing import List
+
+class Ontology(ABC):
+    """Abstract class for ontologies.
+    
+    Ontologies represent hierarchical relationships between terms.
+    """
+
+    @abstractmethod
+    def __init__(self, path):
+        self.terms = {}
+        self.relationships = {}
+        self.path = path
+        self.ids = set()
+        self.names = set()
+    
+    @abstractmethod
+    def get_all_ancestors(self, query_term):
+        pass
+
+    @abstractmethod
+    def get(self, term_id):
+        pass
+
+    def __contains__(self, item):
+        return item in self.terms
+    
+    def __repr__(self):
+        return f"<Ontology.{self.__class__.__name__} {self.path}>"
+
+
+    class Term:
+        """represents an ontology term"""
+
+        def __init__(self, fields: dict, relationships: List['Ontology.Relationship']=None):
+            try:
+                self.id = fields['id']
+            except KeyError:
+                raise ValueError("The 'id' field is required")
+            
+            self.fields = fields
+            self.relationships = relationships
+
+        def __eq__(self, other):
+            if isinstance(other, self.__class__):
+                return self.id == other.id
+            elif isinstance(other, str):
+                return self.id.lower() == other.lower() or self.get("name").lower() == other.lower()
+            elif isinstance(other, int):
+                return self.id.split(":")[1] == other
+            else:
+                return False
+
+        def __repr__(self):
+            return f"<{self.id} {self.get('name')}>"
+
+        def __hash__(self):
+            return hash(self.id)
+
+        def __getattr__(self, attr):
+            return self.fields.get(attr)
+        
+        def get(self, field):
+            return self.fields.get(field)
+
+        
+    class Relationship:
+        """represents a relationship between two ontology terms"""
+
+        def __init__(self, term1, rtype, term2, id=None):
+            self.id = id
+            self.T1 = term1
+            self.rtype = rtype
+            self.T2 = term2
+
+        def __str__(self):
+            return f"Relationship: {self.T1} {self.rtype} {self.T2}"
+
+        def __eq__(self, other):
+            if isinstance(other, Ontology.Term):
+                return self.T2 == other
+            else:
+                return hash(self) == hash(other)
+
+        def __contains__(self, item):
+            return item == self.T1 or item == self.T2
+
+        def __hash__(self):
+            return hash(f"{self.T1} {self.rtype} {self.T2}")
+
+
+class DO(Ontology):
+    """This class represents the Disease Ontology (DO)
+    
+    www.disease-ontology.org
+    """
+    
+    def __init__(self, path):
+        self.terms = {}
+        self.ids = set()
+        self.names = set()
+        self.path = path
+
+        with open(path, 'r') as file:
+            content = file.read()
+            terms = re.findall(r'\[Term\]\n(.*?)\n\n', content, re.DOTALL)
+            for term in terms:
+                term_dict = {}
+                lines = term.split('\n')
+                for line in lines:
+                    if line:
+                        # parse fields into dict
+                        key, value = line.split(': ', 1)
+                        if key in term_dict:
+                            if isinstance(term_dict[key], list):
+                                term_dict[key].append(value)
+                            else:
+                                term_dict[key] = [term_dict[key], value]
+                        else:
+                            term_dict[key] = value
+                # create term object
+                is_a_values = term_dict.get('is_a')
+                if isinstance(is_a_values, list):
+                    relationships = [self.Relationship(term_dict.get("id"), "is_a", other.split(' ! ')[0]) for other in is_a_values]
+                elif isinstance(is_a_values, str):
+                    relationships = [self.Relationship(term_dict.get("id"), "is_a", is_a_values.split(' ! ')[0])]
+                else:
+                    relationships = []
+                new_term = self.Term(term_dict, relationships)
+                # add term to the ontology
+                self.terms[new_term.id] = new_term
+                self.ids.add(new_term.id)
+                self.names.add(new_term.get("name"))
+
+    def get(self, query):
+        """retrieve a term from the ontology
+        
+        query can be one of id (str), id (int), or name (str)
+        examples: "DOID:4947", 4947, "cholangiocarcinoma"
+        """
+        if isinstance(query, int):
+            return self.terms.get(f"DOID:{query}")
+        elif isinstance(query, str):
+            if query.startswith("DOID:"):
+                return self.terms.get(query)
+            else:
+                try:
+                    return self.get(int(query))
+                except ValueError:
+                    return self.get_from_name(query.lower())
+        else:
+            raise ValueError(f"Invalid query type: {type(query)}")
+    
+    def get_from_name(self, name) -> Ontology.Term:
+        """retrieve a term from the ontology by name
+        
+        :param name: the name of the term to retrieve
+        :type  name: str
+        :return: the term object if found, None otherwise
+        """
+        for id, term in self.terms.items():
+            if term == name:
+                return term
+        else:
+            return None
+        
+    def get_all_ancestors(self, query_term, includeSelf=False) -> list:
+        # Get the term corresponding to the query DOID
+        term = self.get(query_term)
+        ancestors = set([term]) if includeSelf else set()
+        if term:
+            visited = set()
+            # Traverse the graph to find all ancestors
+            stack = [term]
+            while stack:
+                current_term = stack.pop()
+                visited.add(current_term.id)
+
+                for parent in [self.get(rel.T2) for rel in term.relationships if rel.rtype == 'is_a']:
+                    if parent.id not in visited:
+                        ancestors.add(parent)
+                        # Add the parent term to the stack for further traversal
+                        stack.append(parent)
+            return list(ancestors)
+        else:
+            return []
+
+    def get_all_ancestor_names(self, query_term) -> list:
+        return [self.get(ancestor).name for ancestor in self.get_all_ancestors(query_term)]
+
+
+class OncoTree(Ontology):
+    """This class represents the OncoTree ontology
+    
+    http://oncotree.info/
+    """
+    ...

--- a/querynator/query_api/civic_api.py
+++ b/querynator/query_api/civic_api.py
@@ -14,12 +14,7 @@ import pandas as pd
 import vcf
 from civicpy import civic
 
-from querynator.helper_functions import (
-    get_num_from_chr,
-    gunzip_compressed_files,
-    gzipped,
-    ontology
-)
+from querynator.helper_functions import get_num_from_chr, gunzip_compressed_files, gzipped, ontology
 
 
 def check_vcf_input(vcf_path, logger):
@@ -536,9 +531,11 @@ def create_civic_results(variant_list, out_path, disease, logger, filter_vep):
     doid = ontology.DO("querynator/helper_functions/doid.obo")
     diseases = doid.get(disease), doid.get_all_ancestors(disease)
     logger.info(f"Mapped specified disease {disease} to Disease Ontology {str(diseases[0])}")
-    
+
     for coord_id_dict, variant in variant_list:
-        civic_result_df = civic_result_df.append(concat_dicts(coord_id_dict, variant, diseases, filter_vep), ignore_index=True)
+        civic_result_df = civic_result_df.append(
+            concat_dicts(coord_id_dict, variant, diseases, filter_vep), ignore_index=True
+        )
 
     logger.info("CIViC Query finished")
     logger.info("Creating Results")

--- a/tests/test_querynator.py
+++ b/tests/test_querynator.py
@@ -10,7 +10,7 @@ from querynator.helper_functions import ontology
 
 
 class testCLI(unittest.TestCase):
-    
+
     def test_commandLineInterface(self):
         """Test the CLI."""
         runner = CliRunner()
@@ -46,6 +46,7 @@ class testCLI(unittest.TestCase):
         result = runner.invoke(querynator.__main__.querynator_cli, ["query-api-cgi", "--baz"])
         assert result.exit_code == 2
         assert "No such option" in result.output
+
 
 class testOntology(unittest.TestCase):
     """Test the ontology classes"""

--- a/tests/test_querynator.py
+++ b/tests/test_querynator.py
@@ -2,51 +2,76 @@
 
 """Tests for `querynator` package."""
 
-from unittest import mock
-
+import unittest
 from click.testing import CliRunner
 
 import querynator.__main__
+from querynator.helper_functions import ontology
 
 
-@mock.patch("querynator.__main__.querynator_cli")
-def test_header(mock_cli):
-    """Just try to execute the header function"""
-    querynator.__main__.run_querynator()
+class testCLI(unittest.TestCase):
+    
+    def test_commandLineInterface(self):
+        """Test the CLI."""
+        runner = CliRunner()
+        result = runner.invoke(querynator.__main__.querynator_cli)
+        assert result.exit_code == 0
+
+        """Test help message"""
+        help_result = runner.invoke(querynator.__main__.querynator_cli, ["--help"])
+        assert help_result.exit_code == 0
+        assert "--help     Show this message and exit." in help_result.output
+
+        """Test CGI help message"""
+        cgi_help_result = runner.invoke(querynator.__main__.querynator_cli, ["query-api-cgi", "--help"])
+        assert cgi_help_result.exit_code == 0
+        assert "--help                          Show this message and exit." in cgi_help_result.output
+
+        """Test CIVIC help message"""
+        civic_help_result = runner.invoke(querynator.__main__.querynator_cli, ["query-api-civic", "--help"])
+        assert civic_help_result.exit_code == 0
+        assert "--help                          Show this message and exit." in civic_help_result.output
+
+        """Test CREATE-REPORT help message"""
+        civic_help_result = runner.invoke(querynator.__main__.querynator_cli, ["create-report", "--help"])
+        assert civic_help_result.exit_code == 0
+        assert "--help                 Show this message and exit." in civic_help_result.output
+
+        """Test non-existing subcommand"""
+        result = runner.invoke(querynator.__main__.querynator_cli, ["query-api-clinvar"])
+        assert result.exit_code == 2
+        assert "No such command" in result.output
+
+        """Test non-existing option"""
+        result = runner.invoke(querynator.__main__.querynator_cli, ["query-api-cgi", "--baz"])
+        assert result.exit_code == 2
+        assert "No such option" in result.output
+
+class testOntology(unittest.TestCase):
+    """Test the ontology classes"""
+
+    def test_disease_ontology(self):
+        """Test the Disease Ontology class"""
+        doid = ontology.DO("querynator/helper_functions/doid.obo")
+        print(doid)
+
+        self.assertIn("DOID:4", doid.ids)
+        self.assertIn("DOID:4", doid.terms)
+        self.assertIn("DOID:4", doid)
+        self.assertIn("DOID:4947", doid)
+
+        term = doid.get("DOID:4947")
+        self.assertEqual(term, doid.get(4947))
+        self.assertEqual(term, doid.get("cholangiocarcinoma"))
+        self.assertEqual(term, doid.get("Cholangiocarcinoma"))
+
+        self.assertIn(doid.get("bile duct adenocarcinoma"), doid.get("cholangiocarcinoma").relationships)
+        self.assertIn(doid.get("bile duct adenocarcinoma"), doid.get_all_ancestors("cholangiocarcinoma"))
+        self.assertIn(doid.get("cholangiocarcinoma"), doid.get_all_ancestors("cholangiocarcinoma", includeSelf=True))
+
+        self.assertIsNone(doid.get("DOID:123456"))
+        self.assertIsNone(doid.get_from_name("foo"))
 
 
-def test_command_line_interface():
-    """Test the CLI."""
-    runner = CliRunner()
-    result = runner.invoke(querynator.__main__.querynator_cli)
-    assert result.exit_code == 0
-
-    """Test help message"""
-    help_result = runner.invoke(querynator.__main__.querynator_cli, ["--help"])
-    assert help_result.exit_code == 0
-    assert "--help     Show this message and exit." in help_result.output
-
-    """Test CGI help message"""
-    cgi_help_result = runner.invoke(querynator.__main__.querynator_cli, ["query-api-cgi", "--help"])
-    assert cgi_help_result.exit_code == 0
-    assert "--help                          Show this message and exit." in cgi_help_result.output
-
-    """Test CIVIC help message"""
-    civic_help_result = runner.invoke(querynator.__main__.querynator_cli, ["query-api-civic", "--help"])
-    assert civic_help_result.exit_code == 0
-    assert "--help                          Show this message and exit." in civic_help_result.output
-
-    """Test CREATE-REPORT help message"""
-    civic_help_result = runner.invoke(querynator.__main__.querynator_cli, ["create-report", "--help"])
-    assert civic_help_result.exit_code == 0
-    assert "--help                 Show this message and exit." in civic_help_result.output
-
-    """Test non-existing subcommand"""
-    result = runner.invoke(querynator.__main__.querynator_cli, ["query-api-clinvar"])
-    assert result.exit_code == 2
-    assert "No such command" in result.output
-
-    """Test non-existing option"""
-    result = runner.invoke(querynator.__main__.querynator_cli, ["query-api-cgi", "--baz"])
-    assert result.exit_code == 2
-    assert "No such option" in result.output
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).
Learn more about contributing: https://github.com/qbic-pipelines/querynator/CONTRIBUTING.md -->

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated
- [ ] `CHANGELOG.rst` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->

- added functionality to specify cancer type to civic queries. (new CL param `-d` / `--cancer-doid`)

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->
- user specifies a cancer type
- `querynator` filters evidence items in results:
  - include evidences from same cancer type
  - include evidences from higher-level cancer type (i.e. when specifying "Cholangiocarcinoma", also include all evidences for "Bile duct adenocarcinoma")
  - include level A evidences for other cancer type as level C evidence for this cancer type (as described in AMP/ASCO/CAT guidelines)

**Additional context**

<!-- Add any other context or screenshots here. -->

CGI and CIViC use different ontologies (CGI: [OncoTree](http://oncotree.info/), CIViC: [Disease-Ontology](https://disease-ontology.org/). Right now they need to be specified separately, passing the burden to map ontologies to the user.
This should be attended to in the future. Let user specify one cancer type, querynator maps to OncoTree / DO, queries, ...